### PR TITLE
Support authenticationDatabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ messages.log
 *.iml
 *.ipr
 *.iws
+target/

--- a/src/main/java/org/mongeez/MongeezRunner.java
+++ b/src/main/java/org/mongeez/MongeezRunner.java
@@ -30,6 +30,7 @@ public class MongeezRunner implements InitializingBean {
     
     private String userName;
     private String passWord;
+    private String authDb;
     
     private ChangeSetFileProvider changeSetFileProvider;
 
@@ -50,7 +51,7 @@ public class MongeezRunner implements InitializingBean {
             mongeez.setFile(file);
             
             if(!StringUtils.isEmpty(userName) && !StringUtils.isEmpty(passWord)){
-            	MongoAuth auth = new MongoAuth(userName, passWord);
+            	MongoAuth auth = new MongoAuth(userName, passWord, authDb);
                 mongeez.setAuth(auth);
             }
         }
@@ -93,5 +94,8 @@ public class MongeezRunner implements InitializingBean {
 	public void setPassWord(String passWord) {
 		this.passWord = passWord;
 	}
-    
+
+    public void setAuthDb(String authDb) {
+        this.authDb = authDb;
+    }
 }

--- a/src/main/java/org/mongeez/MongoAuth.java
+++ b/src/main/java/org/mongeez/MongoAuth.java
@@ -3,16 +3,23 @@ package org.mongeez;
 public class MongoAuth {
 	private String username;
 	private String password;
+    private String authDb;
 	
-	public MongoAuth(String username, String password) {
-		this.username = username;
-		this.password = password;
-	}
-	
-	public String getUsername() {
+    public MongoAuth(String username, String password, String authDb) {
+        this.username = username;
+        this.password = password;
+        this.authDb = authDb;
+
+    }
+
+    public String getUsername() {
 		return username;
 	}
 	public String getPassword() {
 		return password;
 	}
+
+    public String getAuthDb() {
+        return authDb;
+    }
 }

--- a/src/main/java/org/mongeez/dao/MongeezDao.java
+++ b/src/main/java/org/mongeez/dao/MongeezDao.java
@@ -36,9 +36,23 @@ public class MongeezDao {
     }
 
     public MongeezDao(Mongo mongo, String databaseName, MongoAuth auth) {
-        db = mongo.getDB(databaseName);
+
         if (auth != null){
-        	db.authenticate(auth.getUsername(), auth.getPassword().toCharArray());
+            if(auth.getAuthDb() == null || auth.getAuthDb().equals(databaseName))
+            {
+                db = mongo.getDB(databaseName);
+                db.authenticate(auth.getUsername(), auth.getPassword().toCharArray());
+            }
+            else
+            {
+                DB authDb = mongo.getDB(auth.getAuthDb());
+                authDb.authenticate(auth.getUsername(), auth.getPassword().toCharArray());
+                db = mongo.getDB(databaseName);
+            }
+        }
+        else
+        {
+            db = mongo.getDB(databaseName);
         }
         configure();
     }

--- a/src/main/java/org/mongeez/dao/MongeezDao.java
+++ b/src/main/java/org/mongeez/dao/MongeezDao.java
@@ -41,13 +41,17 @@ public class MongeezDao {
             if(auth.getAuthDb() == null || auth.getAuthDb().equals(databaseName))
             {
                 db = mongo.getDB(databaseName);
-                db.authenticate(auth.getUsername(), auth.getPassword().toCharArray());
+                if (!db.authenticate(auth.getUsername(), auth.getPassword().toCharArray())) {
+                    throw new IllegalArgumentException("Failed to authenticate to database [" + databaseName + "]");
+                }
             }
             else
             {
-                DB authDb = mongo.getDB(auth.getAuthDb());
-                authDb.authenticate(auth.getUsername(), auth.getPassword().toCharArray());
                 db = mongo.getDB(databaseName);
+                DB authDb = mongo.getDB(auth.getAuthDb());
+                if (!authDb.authenticate(auth.getUsername(), auth.getPassword().toCharArray())) {
+                    throw new IllegalArgumentException("Failed to authenticate to database [" + auth.getAuthDb() + "]");
+                }
             }
         }
         else


### PR DESCRIPTION
MongoDB allows to have users to be defined in the 'admin' database that have permissions in other databases. See last example in http://docs.mongodb.org/manual/tutorial/add-user-to-database/. Before MongoDB 2.4, a login was automatically checked both in the database you connected to and in the 'admin' database. Since MongoDB 2.4, you need to explicitly mention the authentication database when logging in via the tools. If you login via the Java driver, you need to authenticate to the authentication database before you can connect to the target database.

This issue was recently fixed in Spring-Data-MongoDB 1.4.1, too: https://jira.spring.io/browse/DATAMONGO-789.
